### PR TITLE
Refactor viewModel and interactor

### DIFF
--- a/domain/src/main/java/com/svyd/domain/common/interactor/ParametrizedInteractor.kt
+++ b/domain/src/main/java/com/svyd/domain/common/interactor/ParametrizedInteractor.kt
@@ -1,8 +1,10 @@
 package com.svyd.domain.common.interactor
 
+import com.svyd.domain.common.mapper.TypeMapper
 import com.svyd.domain.common.exception.Failure
 import com.svyd.domain.common.functional.Either
-import com.svyd.domain.common.mapper.TypeMapper
+import com.svyd.domain.common.functional.Either.Left
+import com.svyd.domain.common.functional.Either.Right
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -11,30 +13,33 @@ import kotlinx.coroutines.launch
 
 /**
  * @param Type        domain data type to be returned
+ * @param Params      type of input parameters for the use case
  * @param errorMapper used to map java Throwable to our Failure class
  */
-abstract class Interactor<out Type>(
+abstract class ParametrizedInteractor<out Type, in Params>(
     private val errorMapper: TypeMapper<Throwable, Failure>
 ) {
 
-    abstract suspend fun run(): Flow<Type>
+    abstract suspend fun run(params: Params): Flow<Type>
 
     /**
      * @param TargetType presentation layer data model type
+     * @param params     for the request
      * @param mapper     to map data model from domain Type to presentation layer TargetType type
      *                   it is important to move all data transformation to the background
      *                   execution without exposing data types from other modules
      */
     operator fun <TargetType> invoke(
+        params: Params,
         scope: CoroutineScope,
         mapper: TypeMapper<Type, TargetType>,
         onResult: (Either<Failure, TargetType>) -> Unit = {}
     ) {
         scope.launch {
-            run()
+            run(params)
                 .map { mapper.map(it) }
-                .catch { onResult(Either.Left(errorMapper.map(it))) }
-                .collect { onResult(Either.Right(it)) }
+                .catch { onResult(Left(errorMapper.map(it))) }
+                .collect { onResult(Right(it)) }
         }
     }
 }

--- a/domain/src/main/java/com/svyd/domain/interactor/DirectoryInteractor.kt
+++ b/domain/src/main/java/com/svyd/domain/interactor/DirectoryInteractor.kt
@@ -1,6 +1,6 @@
 package com.svyd.domain.interactor
 
-import com.svyd.domain.common.interactor.Interactor
+import com.svyd.domain.common.interactor.ParametrizedInteractor
 import com.svyd.domain.common.mapper.TypeMapper
 import com.svyd.domain.common.exception.Failure
 import com.svyd.domain.repository.model.Directory
@@ -10,11 +10,8 @@ import kotlinx.coroutines.flow.Flow
 class DirectoryInteractor(
     private val repository: DirectoryRepository,
     errorMapper: TypeMapper<Throwable, Failure>
-) : Interactor<Directory, String>(errorMapper) {
+) : ParametrizedInteractor<Directory, String>(errorMapper) {
 
-    override suspend fun run(params: String): Flow<Directory> {
-        return if (params.isEmpty())
-            repository.rootDirectory() else
-            repository.directory(params)
-    }
+    override suspend fun run(params: String): Flow<Directory> = repository.directory(params)
+
 }

--- a/domain/src/main/java/com/svyd/domain/interactor/RootDirectoryInteractor.kt
+++ b/domain/src/main/java/com/svyd/domain/interactor/RootDirectoryInteractor.kt
@@ -1,0 +1,16 @@
+package com.svyd.domain.interactor
+
+import com.svyd.domain.common.exception.Failure
+import com.svyd.domain.common.interactor.Interactor
+import com.svyd.domain.common.mapper.TypeMapper
+import com.svyd.domain.repository.DirectoryRepository
+import com.svyd.domain.repository.model.Directory
+import kotlinx.coroutines.flow.Flow
+
+class RootDirectoryInteractor(
+    private val repository: DirectoryRepository,
+    errorMapper: TypeMapper<Throwable, Failure>
+) : Interactor<Directory>(errorMapper) {
+
+    override suspend fun run(): Flow<Directory> = repository.rootDirectory()
+}

--- a/presentation/src/main/java/com/svyd/videokilledtheradiostar/feature/browser/data/PlainViewModelProvider.kt
+++ b/presentation/src/main/java/com/svyd/videokilledtheradiostar/feature/browser/data/PlainViewModelProvider.kt
@@ -7,8 +7,10 @@ import com.svyd.data.repository.NetworkDirectoryRepository
 import com.svyd.data.repository.model.mapper.DirectoryMapper
 import com.svyd.domain.common.exception.ErrorMapper
 import com.svyd.domain.common.interactor.Interactor
+import com.svyd.domain.common.interactor.ParametrizedInteractor
 import com.svyd.domain.common.mapper.TypeMapper
 import com.svyd.domain.interactor.DirectoryInteractor
+import com.svyd.domain.interactor.RootDirectoryInteractor
 import com.svyd.domain.repository.DirectoryRepository
 import com.svyd.domain.repository.model.Directory
 import com.svyd.videokilledtheradiostar.feature.browser.model.UiDirectory
@@ -25,8 +27,12 @@ import java.util.concurrent.TimeUnit
 
 class PlainViewModelProvider {
 
-    fun provideInteractor() : Interactor<Directory, String> {
+    fun provideDirectoryInteractor() : ParametrizedInteractor<Directory, String> {
         return DirectoryInteractor(provideRepository(provideService(provideRetrofit()), DirectoryMapper()), ErrorMapper())
+    }
+
+    fun provideRootDirectoryInteractor() : Interactor<Directory> {
+        return RootDirectoryInteractor(provideRepository(provideService(provideRetrofit()), DirectoryMapper()), ErrorMapper())
     }
 
     fun provideMapper() : TypeMapper<Directory, UiDirectory> {

--- a/presentation/src/main/java/com/svyd/videokilledtheradiostar/feature/browser/data/RadioBrowserViewModelFactory.kt
+++ b/presentation/src/main/java/com/svyd/videokilledtheradiostar/feature/browser/data/RadioBrowserViewModelFactory.kt
@@ -3,10 +3,14 @@ package com.svyd.videokilledtheradiostar.feature.browser.data
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 
-class RadioBrowserViewModelFactory(private val url: String) :
+class RadioBrowserViewModelFactory(private val url: String?) :
     ViewModelProvider.NewInstanceFactory() {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         val provider = PlainViewModelProvider()
-        return BrowserViewModel(url, provider.provideInteractor(), provider.provideMapper()) as T
+        return BrowserViewModel(
+            url,
+            provider.provideDirectoryInteractor(),
+            provider.provideRootDirectoryInteractor(),
+            provider.provideMapper()) as T
     }
 }

--- a/presentation/src/main/java/com/svyd/videokilledtheradiostar/feature/browser/ui/RadioBrowserScreen.kt
+++ b/presentation/src/main/java/com/svyd/videokilledtheradiostar/feature/browser/ui/RadioBrowserScreen.kt
@@ -58,7 +58,7 @@ fun VideoKilledTheRadioStarApp() {
 
             composable(route = Browser.route) { backStackEntry ->
                 RadioBrowserScreen(
-                    backStackEntry.arguments?.getString(Destination.URL).orEmpty(),
+                    backStackEntry.arguments?.getString(Destination.URL),
                     padding
                 ) { destinationUrl: String, destinationTitle: String ->
                     navController.navigate(
@@ -103,7 +103,7 @@ fun RadioBrowserTopBar(
 
 @Composable
 fun RadioBrowserScreen(
-    url: String,
+    url: String?,
     padding: PaddingValues,
     onLinkClick: (url: String, title: String) -> Unit
 ) {


### PR DESCRIPTION
avoid using empty string for root directory, 
use nullable string as parameter for viewModel, 
creating more clear distinction between use cases: 
a screen with no url param and the one that has it 

use rather separate interactors (use cases) for root and all other directories, 
making their usage rather transparent from viewModel's point of view. 

just passing non-null string from view to interactor inside viewModel, 
and leaving the interactor to decide, which use case is it, 
creates dependency on logic of a concrete implementation of an interactor. 

furthermore, it is responsibility of a viewModel to decide, which interactor to use. 
otherwise, it is not obvious, how the distinction between root and all other directories is made, 
until you see the implementation of the interactor. 

introduce two types of use cases: 
ParametrizedInteractor.kt and Interactor.kt, which has no parameters.